### PR TITLE
Fix detection of boost static/shared libs

### DIFF
--- a/share/modules/cmake/CMTest.cmake
+++ b/share/modules/cmake/CMTest.cmake
@@ -172,7 +172,7 @@ endif()
         endif ()
     endif ()
 
-    if (BUILD_SHARED_LIBS)
+    if (NOT Boost_USE_STATIC_LIBS)
         target_compile_definitions(${TEST_NAME} PRIVATE -DBOOST_TEST_DYN_LINK=1 -DBOOST_TEST_NO_AUTO_LINK=1)
     endif ()
 


### PR DESCRIPTION
Use proper variable `Boost_USE_STATIC_LIBS` to detect whether the test will be linked with static library or shared